### PR TITLE
Bump version of ring dependency + loosen dependency requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-lazy_static = { version = "1.4.0", optional = true }
-cpufeatures = { version = "0.2.5", optional = true }
-ring = "0.16.20"
-sha2 = "0.10.6"
+lazy_static = { version = "1.1", optional = true }
+cpufeatures = { version = "0.2", optional = true }
+ring = "0.17"
+sha2 = "0.10"
 
 [dev-dependencies]
-rustc-hex = "2.1.0"
+rustc-hex = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.33"


### PR DESCRIPTION
See #5
@michaelsproul 

I've also checked compatibility with the following and loosened the restrictions on the other dependencies (except for wasm-bindgen):
```bash
cargo +nightly -Z minimal-versions update && cargo test
# Or this where the above didn't work due to transitive dependencies
cargo +nightly -Z direct-minimal-versions update && cargo test
```

It should also be possible to use `ring = ">= 0.16, < 1.18"`, which wouldn't force a breaking change as far as I can tell, though due to this recommendation in https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-version-requirements I'm not sure if that's a good idea.