### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_hashing"
-version = "1.0.0-beta.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
New release to include the `ring` update to v0.17

This is technically a breaking change (minor version update in a dep), so requires a minor version bump.

We are abandoning the 1.0 versioning too, as not all dependencies are 1.0