### PR TITLE
Remove lazy_static dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/sigp/ethereum_hashing"
 documentation = "https://docs.rs/ethereum_hashing"
 keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
+rust-version = "1.80.0"
 
 [dependencies]
-lazy_static = { version = "1.1", optional = true }
 ring = "0.17"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
@@ -26,4 +26,4 @@ wasm-bindgen-test = "0.3.33"
 
 [features]
 default = ["zero_hash_cache"]
-zero_hash_cache = ["lazy_static"]
+zero_hash_cache = []


### PR DESCRIPTION
Replace `lazy_static` by new `LazyLock` type stabilised in Rust 1.80.0.

This required bumping the MSRV.