### PR TITLE
Ensure codecov token is used

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -46,3 +46,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fix failing `cargo-tarpaulin` CI.