### PR TITLE
Add lazy cell feature flag for compatibility with older Rust nighty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! Now this crate serves primarily as a wrapper over two SHA256 crates: `sha2` and `ring` – which
 //! it switches between at runtime based on the availability of SHA intrinsics.
-
+#![allow(stable_features)]
+#![feature(lazy_cell)]
 mod sha2_impl;
 
 pub use self::DynamicContext as Context;


### PR DESCRIPTION
Lockbud runs on Rust nightly-2024-5-21, where lazy_cell was still unstable. If we want lockbud enabled in Lighthouse CI we need this feature flag.