### PR TITLE
Feature gate ring for Miri support

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Run tests
-      run: cargo test --release --no-default-features --features ${{ matrix.features }}
+      run: cargo test --release --no-default-features --features "${{ matrix.features }}"
   # We use `--skip-clean` to aggregate the coverage from runs with different features.
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,6 +24,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         features: ["", "ring", "zero_hash_cache", "ring,zero_hash_cache"]
+        # Skip the ring-less builds on macOS ARM where ring is mandatory.
+        exclude:
+        - os: macos-latest
+          features: ""
+        - os: macos-latest
+          features: "zero_hash_cache"
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.os }}-feat-${{ matrix.features }}
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,14 +23,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        features: ["", "ring", "zero_hash_cache", "ring,zero_hash_cache"]
     runs-on: ${{ matrix.os }}
-    name: test-${{ matrix.os }}
+    name: test-${{ matrix.os }}-feat-${{ matrix.features }}
     steps:
     - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Run tests
-      run: cargo test --release
+      run: cargo test --release --no-default-features --features ${{ matrix.features }}
+  # We use `--skip-clean` to aggregate the coverage from runs with different features.
   coverage:
     runs-on: ubuntu-latest
     name: cargo-tarpaulin
@@ -40,8 +42,14 @@ jobs:
       run: rustup update stable
     - name: Install cargo-tarpaulin
       uses: taiki-e/install-action@cargo-tarpaulin
-    - name: Check code coverage with cargo-tarpaulin
-      run: cargo-tarpaulin --workspace --all-features --out xml
+    - name: Check code coverage with cargo-tarpaulin (no features)
+      run: cargo-tarpaulin --workspace --out xml --no-default-features
+    - name: Check code coverage with cargo-tarpaulin (just `ring` feature)
+      run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "ring"
+    - name: Check code coverage with cargo-tarpaulin (just `zero_hash_cache` feature)
+      run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "zero_hash_cache"
+    - name: Check code coverage with cargo-tarpaulin (all features)
+      run: cargo-tarpaulin --workspace --out xml --skip-clean --all-features
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies"]
 rust-version = "1.80.0"
 
 [dependencies]
-ring = "0.17"
+ring = { version = "0.17", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpufeatures = "0.2"
@@ -25,5 +25,6 @@ rustc-hex = "2"
 wasm-bindgen-test = "0.3.33"
 
 [features]
-default = ["zero_hash_cache"]
+default = ["zero_hash_cache", "ring"]
 zero_hash_cache = []
+ring = ["dep:ring"]


### PR DESCRIPTION
Ring contains a call to `OPENSSL_cpuid_setup` which is not supported by [Miri](https://github.com/rust-lang/miri) [it can't handle most FFI].

This PR feature-gates `ring` so that we can build `ethereum_hashing` without it. This enables us to run the test suites for `tree_hash` and `ssz_types` using Miri, which is increasingly important with the introduction of `unsafe` code in:

- https://github.com/sigp/ssz_types/pull/55

This change is unfortunately **not** _backwards-compatible_, as downstream users compiling with `default-features = false` might have their build broken by the exclusion of `ring` (on a non-x86_64 platform). Therefore this PR necessitates a minor version bump.