### PR TITLE
Add portable feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.80.0"
 
 [dependencies]
 ring = { version = "0.17", optional = true }
+sha2 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpufeatures = "0.2"
-sha2 = "0.10"
 
 [dev-dependencies]
 rustc-hex = "2"
@@ -28,3 +28,4 @@ wasm-bindgen-test = "0.3.33"
 default = ["zero_hash_cache", "ring"]
 zero_hash_cache = []
 ring = ["dep:ring"]
+portable = ["dep:sha2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustc-hex = "2"
 wasm-bindgen-test = "0.3.33"
 
 [features]
-default = ["zero_hash_cache", "ring"]
+default = ["zero_hash_cache", "portable"]
 zero_hash_cache = []
 ring = ["dep:ring"]
 portable = ["dep:sha2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,17 @@ mod tests {
         assert_eq!(expected, output);
     }
 
+    #[cfg(feature = "portable")]
+    #[test]
+    fn test_portable_hashing() {
+        let input: Vec<u8> = b"hello world".as_ref().into();
+
+        let output = hash(input.as_ref());
+        let expected_hex = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        let expected: Vec<u8> = expected_hex.from_hex().unwrap();
+        assert_eq!(expected, output);
+    }
+
     #[cfg(feature = "zero_hash_cache")]
     mod zero_hash {
         use super::*;

--- a/src/sha2_impl.rs
+++ b/src/sha2_impl.rs
@@ -1,6 +1,6 @@
 // This implementation should only be compiled on x86_64 due to its dependency on the `sha2` and
 // `cpufeatures` crates which do not compile on some architectures like RISC-V.
-#![cfg(target_arch = "x86_64")]
+#![cfg(any(target_arch = "x86_64", feature = "portable"))]
 
 use crate::{Sha256, Sha256Context, HASH_LEN};
 use sha2::Digest;


### PR DESCRIPTION
I have added a portable feature to the crate, which enables usage of this crate on any architecture without relying on ring.

I have added this, because I am using the tree-hash crate and would like to run this in a zkVM, where the ring c-bindings are an issue. The changes are backwards compatible and also allow using SP1 precompiles via a simple [patch](https://docs.succinct.xyz/docs/sp1/optimizing-programs/precompiles#patched-crates).

Everything should be backwards compatible, please let me know if any changes are needed