### PR TITLE
Add sha2 support for non-x86_64 platforms via feature gate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.80.0"
 
 [dependencies]
 ring = { version = "0.17", optional = true }
+sha2 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpufeatures = "0.2"
@@ -28,3 +29,4 @@ wasm-bindgen-test = "0.3.33"
 default = ["zero_hash_cache", "ring"]
 zero_hash_cache = []
 ring = ["dep:ring"]
+sha2 = ["dep:sha2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,15 @@ impl DynamicImpl {
         }
 
         // Compile error if no implementation available
-        #[cfg(all(not(feature = "ring"), not(target_arch = "x86_64"), not(feature = "sha2")))]
+        #[cfg(all(
+            not(feature = "ring"),
+            not(target_arch = "x86_64"),
+            not(feature = "sha2")
+        ))]
         {
-            compile_error!("Either 'ring' or 'sha2' feature must be enabled on non-x86_64 architectures");
+            compile_error!(
+                "Either 'ring' or 'sha2' feature must be enabled on non-x86_64 architectures"
+            );
         }
     }
 }

--- a/src/sha2_impl.rs
+++ b/src/sha2_impl.rs
@@ -1,6 +1,5 @@
-// This implementation should only be compiled on x86_64 due to its dependency on the `sha2` and
-// `cpufeatures` crates which do not compile on some architectures like RISC-V.
-#![cfg(target_arch = "x86_64")]
+// This implementation is compiled on x86_64 (always has sha2) or when the sha2 feature is enabled.
+#![cfg(any(target_arch = "x86_64", feature = "sha2"))]
 
 use crate::{Sha256, Sha256Context, HASH_LEN};
 use sha2::Digest;


### PR DESCRIPTION
Quick attempt to allow usage of sha2 on targets like WASM or RISC-V.

This would help fixing https://github.com/sigp/ssz_types/issues/79, because users could just add explicit `ethereum_hashing` dependency with `sha2` feature enabled - then it could be compiled in zkVM.