### PR TITLE
Add additional architectures to CI checks

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -100,18 +100,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get latest version of stable Rust
         run: rustup update stable
-      - name: Install aarch64 target
-        run: rustup target add aarch64-unknown-linux-gnu
-      - name: Install cross-compilation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-      - name: Build for ARM64
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
       - name: Install cross
         uses: taiki-e/install-action@cross
+      - name: Build for ARM64 with cross
+        run: cross build --target aarch64-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
       - name: Run ARM64 tests with cross (QEMU)
         run: cross test --target aarch64-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
 
@@ -147,18 +139,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get latest version of stable Rust
         run: rustup update stable
-      - name: Install armv7 target
-        run: rustup target add armv7-unknown-linux-gnueabihf
-      - name: Install cross-compilation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-      - name: Build for ARMv7
-        env:
-          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
-        run: cargo build --target armv7-unknown-linux-gnueabihf --no-default-features --features "${{ matrix.features }}"
       - name: Install cross
         uses: taiki-e/install-action@cross
+      - name: Build for ARMv7 with cross
+        run: cross build --target armv7-unknown-linux-gnueabihf --no-default-features --features "${{ matrix.features }}"
       - name: Run ARMv7 tests with cross (QEMU)
         run: cross test --target armv7-unknown-linux-gnueabihf --no-default-features --features "${{ matrix.features }}"
 
@@ -177,12 +161,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get latest version of stable Rust
         run: rustup update stable
-      - name: Install riscv64 target
-        run: rustup target add riscv64gc-unknown-linux-gnu
-      - name: Build for RISC-V 64
-        run: cargo build --target riscv64gc-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
       - name: Install cross
         uses: taiki-e/install-action@cross
+      - name: Build for RISC-V 64 with cross
+        run: cross build --target riscv64gc-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
       - name: Run RISC-V 64 tests with cross (QEMU)
         run: cross test --target riscv64gc-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -4,61 +4,225 @@ on:
   push:
     branches:
       - main
-      - 'pr/*'
+      - "pr/*"
   pull_request:
+
 env:
   # Deny warnings in CI
   RUSTFLAGS: "-D warnings"
+
 jobs:
   cargo-fmt:
     name: cargo-fmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Get latest version of stable Rust
-      run: rustup update stable
-    - name: Check formatting with cargo fmt
-      run: cargo fmt --all -- --check
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Check formatting with cargo fmt
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Run clippy (all features)
+        run: cargo clippy --all-features -- -D warnings
+      - name: Run clippy (sha2 only)
+        run: cargo clippy --no-default-features --features "sha2,zero_hash_cache" -- -D warnings
+      - name: Run clippy (ring only)
+        run: cargo clippy --no-default-features --features "ring,zero_hash_cache" -- -D warnings
+
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        features: ["", "ring", "zero_hash_cache", "ring,zero_hash_cache"]
-        # Skip the ring-less builds on macOS ARM where ring is mandatory.
-        exclude:
-        - os: macos-latest
-          features: ""
-        - os: macos-latest
-          features: "zero_hash_cache"
+        features:
+          - "sha2"
+          - "ring"
+          - "sha2,zero_hash_cache"
+          - "ring,zero_hash_cache"
+          - "sha2,ring,zero_hash_cache"
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.os }}-feat-${{ matrix.features }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Get latest version of stable Rust
-      run: rustup update stable
-    - name: Run tests
-      run: cargo test --release --no-default-features --features "${{ matrix.features }}"
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Run tests
+        run: cargo test --release --no-default-features --features "${{ matrix.features }}"
+
+  test-wasm:
+    name: test-wasm32-${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: "sha2"
+            features: "sha2"
+          - name: "sha2,zero_hash_cache"
+            features: "sha2,zero_hash_cache"
+          # ring requires ring-wasm for WASM support
+          - name: "ring"
+            features: "ring-wasm"
+          - name: "ring,zero_hash_cache"
+            features: "ring-wasm,zero_hash_cache"
+          - name: "sha2,ring,zero_hash_cache"
+            features: "sha2,ring-wasm,zero_hash_cache"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build for WASM
+        run: cargo build --target wasm32-unknown-unknown --no-default-features --features "${{ matrix.features }}"
+      - name: Run WASM tests (Node.js)
+        run: wasm-pack test --node --no-default-features --features "${{ matrix.features }}"
+
+  test-arm64:
+    name: test-aarch64-linux-${{ matrix.features }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "sha2"
+          - "ring"
+          - "sha2,zero_hash_cache"
+          - "ring,zero_hash_cache"
+          - "sha2,ring,zero_hash_cache"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install aarch64 target
+        run: rustup target add aarch64-unknown-linux-gnu
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - name: Build for ARM64
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - name: Run ARM64 tests with cross (QEMU)
+        run: cross test --target aarch64-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
+
+  test-arm64-macos:
+    name: test-aarch64-macos-${{ matrix.features }}
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        features:
+          - "sha2"
+          - "ring"
+          - "sha2,zero_hash_cache"
+          - "ring,zero_hash_cache"
+          - "sha2,ring,zero_hash_cache"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Run tests
+        run: cargo test --release --no-default-features --features "${{ matrix.features }}"
+
+  test-armv7:
+    name: test-armv7-linux-${{ matrix.features }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "sha2"
+          - "ring"
+          - "sha2,zero_hash_cache"
+          - "ring,zero_hash_cache"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install armv7 target
+        run: rustup target add armv7-unknown-linux-gnueabihf
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+      - name: Build for ARMv7
+        env:
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+        run: cargo build --target armv7-unknown-linux-gnueabihf --no-default-features --features "${{ matrix.features }}"
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - name: Run ARMv7 tests with cross (QEMU)
+        run: cross test --target armv7-unknown-linux-gnueabihf --no-default-features --features "${{ matrix.features }}"
+
+  test-riscv64:
+    name: test-riscv64-linux-${{ matrix.features }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "sha2"
+          - "ring"
+          - "sha2,zero_hash_cache"
+          - "ring,zero_hash_cache"
+          - "sha2,ring,zero_hash_cache"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install riscv64 target
+        run: rustup target add riscv64gc-unknown-linux-gnu
+      - name: Build for RISC-V 64
+        run: cargo build --target riscv64gc-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - name: Run RISC-V 64 tests with cross (QEMU)
+        run: cross test --target riscv64gc-unknown-linux-gnu --no-default-features --features "${{ matrix.features }}"
+
   # We use `--skip-clean` to aggregate the coverage from runs with different features.
   coverage:
     runs-on: ubuntu-latest
     name: cargo-tarpaulin
     steps:
-    - uses: actions/checkout@v3
-    - name: Get latest version of stable Rust
-      run: rustup update stable
-    - name: Install cargo-tarpaulin
-      uses: taiki-e/install-action@cargo-tarpaulin
-    - name: Check code coverage with cargo-tarpaulin (no features)
-      run: cargo-tarpaulin --workspace --out xml --no-default-features
-    - name: Check code coverage with cargo-tarpaulin (just `ring` feature)
-      run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "ring"
-    - name: Check code coverage with cargo-tarpaulin (just `zero_hash_cache` feature)
-      run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "zero_hash_cache"
-    - name: Check code coverage with cargo-tarpaulin (all features)
-      run: cargo-tarpaulin --workspace --out xml --skip-clean --all-features
-    - name: Upload to codecov.io
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        informational: true
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@cargo-tarpaulin
+      - name: Check code coverage (sha2 only)
+        run: cargo-tarpaulin --workspace --out xml --no-default-features --features "sha2"
+      - name: Check code coverage (ring only)
+        run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "ring"
+      - name: Check code coverage (sha2 + zero_hash_cache)
+        run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "sha2,zero_hash_cache"
+      - name: Check code coverage (ring + zero_hash_cache)
+        run: cargo-tarpaulin --workspace --out xml --skip-clean --no-default-features --features "ring,zero_hash_cache"
+      - name: Check code coverage (all features)
+        run: cargo-tarpaulin --workspace --out xml --skip-clean --all-features
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          informational: true
+
+  msrv:
+    name: msrv-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install MSRV Rust (1.83.0)
+        run: rustup install 1.83.0 && rustup default 1.83.0
+      - name: Check with MSRV (sha2)
+        run: cargo check --no-default-features --features "sha2,zero_hash_cache"
+      - name: Check with MSRV (ring)
+        run: cargo check --no-default-features --features "ring,zero_hash_cache"
+      - name: Check with MSRV (all features)
+        run: cargo check --all-features

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,11 +16,11 @@ jobs:
     name: cargo-fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        run: rustup update stable
-      - name: Check formatting with cargo fmt
-        run: cargo fmt --all -- --check
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Check formatting with cargo fmt
+      run: cargo fmt --all -- --check
 
   clippy:
     name: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/sigp/ethereum_hashing"
 documentation = "https://docs.rs/ethereum_hashing"
 keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
-rust-version = "1.80.0"
+rust-version = "1.83.0"
 
 [dependencies]
 ring = { version = "0.17", optional = true }
@@ -30,3 +30,6 @@ default = ["zero_hash_cache", "ring"]
 zero_hash_cache = []
 ring = ["dep:ring"]
 sha2 = ["dep:sha2"]
+# Enable ring's WASM support (wasm32-unknown-unknown target).
+# This enables getrandom's js feature for Web API-based randomness.
+ring-wasm = ["ring", "ring/wasm32_unknown_unknown_js"]


### PR DESCRIPTION
## Proposed Changes

This PR adds additional architectures to CI checks. We now test:
- x86-64
- WASM
- ARM64
- ARMv7
- ARM-MacOS
- RISCV64

We check each architecture with both Ring and SHA2.

## Additional Info
There's some noise from my IDE autoformatting yaml files